### PR TITLE
Add shortcut option for invoking search card

### DIFF
--- a/translate v1.1/manifest.json
+++ b/translate v1.1/manifest.json
@@ -43,5 +43,13 @@
         "js/jquery/jquery.js"
       ]
     }
-  ]
+  ],
+  "commands":{
+    "invoke-inpage-search": {
+      "suggested_key": {
+        "default": "Alt+Shift+J"
+      },
+      "description": "Extra key combination to invoke in-page search"
+    }
+  }
 }

--- a/translate v1.1/src/bg/background.js
+++ b/translate v1.1/src/bg/background.js
@@ -33,3 +33,24 @@ function returnMessage(current) {
     });
   });
 }
+
+function invokeSearch() {
+  var sel = window.getSelection().toString();
+  if (!sel.length) return;
+  chrome.extension.sendRequest({
+    message: encodeURI(sel)
+  });
+}
+
+function getJsCode(func) {
+  return ';(' + func + ')();';
+}
+
+chrome.commands.onCommand.addListener(function (command) {
+  if (command == "invoke-inpage-search") {
+    chrome.tabs.executeScript({
+      code: getJsCode(invokeSearch),
+      allFrames: true
+    })
+  }
+})


### PR DESCRIPTION
For some websites e.g. Slack, pressing only "J" will activate input fields and cause the search to fail i.e. no card being shown.

For those websites, 2x modifier keys + alpohabet key is usually enough to invoke search without activating input field. There's no such option, so I added one that the user can set for themselves.

Screenshot:
![image](https://user-images.githubusercontent.com/6729737/80067415-be177700-8578-11ea-84ab-53eb0e4ea766.png)
